### PR TITLE
Fix/block missing

### DIFF
--- a/internal/data/metrics.sql.go
+++ b/internal/data/metrics.sql.go
@@ -16,10 +16,9 @@ INSERT into block(
 	block_hash,
 	block_number,
 	block_timestamp,
-	tx_hash,
 	slot
 ) 
-VALUES ($1, $2, $3, $4, $5) 
+VALUES ($1, $2, $3, $4) 
 ON CONFLICT DO NOTHING
 `
 
@@ -27,7 +26,6 @@ type CreateBlockParams struct {
 	BlockHash      []byte
 	BlockNumber    int64
 	BlockTimestamp int64
-	TxHash         []byte
 	Slot           int64
 }
 
@@ -36,7 +34,6 @@ func (q *Queries) CreateBlock(ctx context.Context, arg CreateBlockParams) error 
 		arg.BlockHash,
 		arg.BlockNumber,
 		arg.BlockTimestamp,
-		arg.TxHash,
 		arg.Slot,
 	)
 	return err
@@ -352,7 +349,7 @@ func (q *Queries) CreateValidatorStatus(ctx context.Context, arg CreateValidator
 }
 
 const queryBlockFromSlot = `-- name: QueryBlockFromSlot :one
-SELECT block_hash, block_number, block_timestamp, tx_hash, created_at, updated_at, slot FROM block
+SELECT block_hash, block_number, block_timestamp, created_at, updated_at, slot FROM block
 WHERE slot = $1 FOR UPDATE
 `
 
@@ -363,7 +360,6 @@ func (q *Queries) QueryBlockFromSlot(ctx context.Context, slot int64) (Block, er
 		&i.BlockHash,
 		&i.BlockNumber,
 		&i.BlockTimestamp,
-		&i.TxHash,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.Slot,

--- a/internal/data/models.sqlc.gen.go
+++ b/internal/data/models.sqlc.gen.go
@@ -100,7 +100,6 @@ type Block struct {
 	BlockHash      []byte
 	BlockNumber    int64
 	BlockTimestamp int64
-	TxHash         []byte
 	CreatedAt      pgtype.Timestamptz
 	UpdatedAt      pgtype.Timestamptz
 	Slot           int64

--- a/internal/data/sql/queries/metrics.sql
+++ b/internal/data/sql/queries/metrics.sql
@@ -72,10 +72,9 @@ INSERT into block(
 	block_hash,
 	block_number,
 	block_timestamp,
-	tx_hash,
 	slot
 ) 
-VALUES ($1, $2, $3, $4, $5) 
+VALUES ($1, $2, $3, $4) 
 ON CONFLICT DO NOTHING;
 
 -- name: QueryBlockFromSlot :one

--- a/internal/metrics/tx_mapper_db.go
+++ b/internal/metrics/tx_mapper_db.go
@@ -203,7 +203,6 @@ func (tm *TxMapperDB) AddBlock(
 		BlockHash:      b.BlockHash,
 		BlockNumber:    b.BlockNumber,
 		BlockTimestamp: b.BlockTimestamp,
-		TxHash:         b.TxHash,
 		Slot:           b.Slot,
 	})
 	if err != nil {

--- a/internal/watcher/decryption_keys.go
+++ b/internal/watcher/decryption_keys.go
@@ -82,7 +82,6 @@ func (pmw *P2PMsgsWatcher) insertBlock(ctx context.Context, ev *BlockReceivedEve
 		BlockHash:      ev.Header.Hash().Bytes(),
 		BlockNumber:    ev.Header.Number.Int64(),
 		BlockTimestamp: int64(ev.Header.Time),
-		TxHash:         ev.Header.TxHash[:],
 		Slot:           int64(utils.GetSlotForBlock(ev.Header.Time, GenesisTimestamp, SlotDuration)),
 	})
 	if err != nil {

--- a/migrations/20240913173451_drop_tx_hash_from_block.sql
+++ b/migrations/20240913173451_drop_tx_hash_from_block.sql
@@ -1,0 +1,8 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE block DROP COLUMN tx_hash;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- +goose StatementEnd


### PR DESCRIPTION
We were storing the Merkle root of transactions in the `block` table with a unique constraint. Blocks are only added to the database when there are no conflicts. However, since the Merkle root can be the same for blocks with no transactions (which is common on Gnosis mainnet/Chiado), the conflict condition gets triggered, preventing those blocks from being saved in the database.

The fix is straightforward: since the Merkle root is not needed or used in our observer, we can simply remove it from the `block` table.

Closes #42