### PR TITLE
Migration fix

### DIFF
--- a/migrations/20240723154230_add_decrypted_tx_table.sql
+++ b/migrations/20240723154230_add_decrypted_tx_table.sql
@@ -1,11 +1,20 @@
 -- +goose Up
 -- +goose StatementBegin
 
-CREATE TYPE IF NOT EXISTS tx_status_val AS ENUM 
-(
-    'included', 
-    'not included'
-);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 
+        FROM pg_type 
+        WHERE typname = 'tx_status_val'
+    ) THEN
+        CREATE TYPE tx_status_val AS ENUM 
+        (
+            'included', 
+            'not included'
+        );
+    END IF;
+END $$;
 
 
 CREATE TABLE IF NOT EXISTS decrypted_tx

--- a/migrations/20240805163859_add_validator_table.sql
+++ b/migrations/20240805163859_add_validator_table.sql
@@ -1,11 +1,21 @@
 -- +goose Up
 -- +goose StatementBegin
-CREATE TYPE IF NOT EXISTS validator_registration_validity AS ENUM 
-(
-    'valid', 
-    'invalid message',
-    'invalid signature'
-);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 
+        FROM pg_type 
+        WHERE typname = 'validator_registration_validity'
+    ) THEN
+    CREATE TYPE validator_registration_validity AS ENUM 
+        (
+            'valid', 
+            'invalid message',
+            'invalid signature'
+        );
+    END IF;
+END $$;
 
 CREATE TABLE IF NOT EXISTS validator_registration_message
 (


### PR DESCRIPTION
Currently when goose up runs after first attempt it does not create some tables as the types already exists. This PR solves the issue by first checking if the type exists, it does not try to create it again.

Found this issue while deploying newer versions of shutter explorer.