### PR TITLE
fix logging to have string based logs in place of json based logs

### DIFF
--- a/common/logging.go
+++ b/common/logging.go
@@ -1,0 +1,22 @@
+package common
+
+import (
+	"os"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+// SetupLogging configures zerolog to output in string format instead of JSON.
+func SetupLogging() {
+	log.Logger = log.Output(zerolog.ConsoleWriter{
+		Out:        os.Stderr,
+		TimeFormat: zerolog.TimeFieldFormat,
+		PartsOrder: []string{
+			zerolog.TimestampFieldName,
+			zerolog.LevelFieldName,
+			zerolog.CallerFieldName,
+			zerolog.MessageFieldName,
+		},
+	})
+}

--- a/main.go
+++ b/main.go
@@ -5,9 +5,11 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"github.com/shutter-network/observer/cmd/cli"
+	"github.com/shutter-network/observer/common"
 )
 
 func main() {
+	common.SetupLogging()
 	status := 0
 	if err := cli.Cmd().Execute(); err != nil {
 		log.Info().Err(err).Msg("failed running server")


### PR DESCRIPTION
closes https://github.com/shutter-network/observer/issues/88